### PR TITLE
feat: implement values UI refactor with drag-and-drop

### DIFF
--- a/frontend/app/(dashboard)/page.tsx
+++ b/frontend/app/(dashboard)/page.tsx
@@ -2,7 +2,6 @@
 
 import { useAuth } from '@/lib/auth-context';
 import { WelcomeCard } from '@/components/dashboard/WelcomeCard';
-import { QuickStatsCard } from '@/components/dashboard/QuickStatsCard';
 import { FeatureCard } from '@/components/dashboard/FeatureCard';
 import { ValuesPreview } from '@/components/dashboard/ValuesPreview';
 import { Brain, Target, Heart, Compass, Activity, Clock } from 'lucide-react';
@@ -14,40 +13,6 @@ export default function DashboardPage() {
     <div className="space-y-8">
       {/* Welcome Section */}
       <WelcomeCard userName={user?.name || 'there'} />
-
-      {/* Quick Stats Section */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <QuickStatsCard
-          title="Thinks"
-          value={0}
-          description="Ideas captured"
-          trend="+2 this week"
-          icon={Brain}
-          color="blue"
-        />
-        <QuickStatsCard
-          title="Values"
-          value={0}
-          description="Core values"
-          icon={Heart}
-          color="red"
-        />
-        <QuickStatsCard
-          title="Goals"
-          value={0}
-          description="Active goals"
-          icon={Target}
-          color="green"
-        />
-        <QuickStatsCard
-          title="Habits"
-          value={0}
-          description="Daily habits"
-          trend="5 day streak"
-          icon={Activity}
-          color="purple"
-        />
-      </div>
 
       {/* Values Preview Section */}
       <ValuesPreview />

--- a/frontend/app/(dashboard)/values/page.tsx
+++ b/frontend/app/(dashboard)/values/page.tsx
@@ -135,9 +135,8 @@ export default function ValuesPage() {
         <Alert className="bg-rose-50 border-rose-200">
           <Info className="h-4 w-4 text-rose-600" />
           <AlertDescription className="text-sm text-rose-900">
-            You can define up to <strong>10 core values</strong>. Values are ranked by priority,
-            with #1 being your most important value. Choose values that truly guide your life
-            decisions.
+            You can define up to <strong>10 core values</strong>. Drag to reorder and set your
+            priorities. Gaps are allowed when you delete values.
           </AlertDescription>
         </Alert>
       </div>

--- a/frontend/components/dashboard/ValuesPreview.tsx
+++ b/frontend/components/dashboard/ValuesPreview.tsx
@@ -19,11 +19,16 @@ export function ValuesPreview() {
     const fetchValues = async () => {
       try {
         const response = await api.values.getAll();
-        // Show top 3 values
-        setValues(response.items.slice(0, 3));
+        // Sort by displayOrder and show all values
+        const sortedValues = [...response.items].sort(
+          (a, b) => a.displayOrder - b.displayOrder,
+        );
+        setValues(sortedValues);
         setError(null);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load values preview');
+      } catch (err: unknown) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to load values preview';
+        setError(errorMessage);
       } finally {
         setIsLoading(false);
       }
@@ -79,25 +84,21 @@ export function ValuesPreview() {
             href="/values"
             className="text-rose-600 hover:text-rose-700 flex items-center gap-1 text-sm font-medium"
           >
-            View all
+            Manage
             <ArrowRight className="h-4 w-4" />
           </Link>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
-        {values.map((value, index) => {
+        {values.map((value) => {
           const facetConfig = getFacetConfig(value.facet);
           return (
             <div key={value.id} className="flex items-start gap-3 p-3 rounded-lg bg-muted/50">
               <Badge
                 variant="outline"
-                className={
-                  index === 0
-                    ? 'bg-rose-100 text-rose-800 border-rose-300 font-semibold shrink-0'
-                    : 'bg-gray-100 text-gray-700 border-gray-300 shrink-0'
-                }
+                className="bg-gray-100 text-gray-700 border-gray-300 shrink-0"
               >
-                #{index + 1}
+                #{value.displayOrder}
               </Badge>
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium line-clamp-2">{value.content}</p>

--- a/frontend/components/features/EmptySlot.tsx
+++ b/frontend/components/features/EmptySlot.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+interface EmptySlotProps {
+  slotNumber: number;
+}
+
+export function EmptySlot({ slotNumber }: EmptySlotProps) {
+  return (
+    <div className="flex gap-2 items-stretch">
+      {/* Spacer for drag handle alignment */}
+      <div className="w-9 flex-shrink-0" />
+
+      {/* Empty slot card */}
+      <div className="flex-1 h-24 bg-muted/20 border-2 border-dashed border-muted-foreground/20 rounded-lg flex items-center justify-center">
+        <span className="text-sm text-muted-foreground">
+          Slot #{slotNumber} - Empty
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/features/ValueCard.tsx
+++ b/frontend/components/features/ValueCard.tsx
@@ -4,10 +4,15 @@ import { Value } from '@/lib/types';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Edit, Trash2 } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Edit, Trash2, MoreVertical } from 'lucide-react';
 import { getFacetConfig } from '@/lib/value-utils';
 
-// Gradient backgrounds based on facet
 const gradientMap: Record<string, string> = {
   health: 'bg-gradient-to-br from-emerald-50 to-white',
   relationships: 'bg-gradient-to-br from-blue-50 to-white',
@@ -21,36 +26,37 @@ const gradientMap: Record<string, string> = {
 
 interface ValueCardProps {
   value: Value;
-  rank: number; // 1-based ranking (1 = most important)
+  rank: number;
   onEdit?: () => void;
   onDelete?: () => void;
+  isDragging?: boolean;
 }
 
-export function ValueCard({ value, rank, onEdit, onDelete }: ValueCardProps) {
+export function ValueCard({
+  value,
+  rank,
+  onEdit,
+  onDelete,
+  isDragging = false,
+}: ValueCardProps) {
   const facetConfig = getFacetConfig(value.facet);
-  const isTopValue = rank === 1;
-
   const gradientClass = gradientMap[value.facet] || 'bg-white';
 
   return (
     <Card
-      className={`transition-all hover:shadow-md ${gradientClass} ${
-        isTopValue ? 'ring-2 ring-rose-500' : 'hover:border-rose-200'
+      className={`transition-all ${gradientClass} hover:border-rose-200 ${
+        isDragging ? 'shadow-lg border-rose-300' : 'hover:shadow-md'
       }`}
     >
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
-          <div className="flex items-center gap-2 flex-wrap">
-            {/* Priority Badge */}
+          <div className="flex items-center gap-2 flex-wrap flex-1">
+            {/* Priority Badge - uniform styling for all */}
             <Badge
               variant="outline"
-              className={
-                isTopValue
-                  ? 'bg-rose-100 text-rose-800 border-rose-300 font-semibold'
-                  : 'bg-gray-100 text-gray-700 border-gray-300'
-              }
+              className="bg-gray-100 text-gray-700 border-gray-300"
             >
-              {isTopValue ? '#1 Core Value' : `#${rank}`}
+              #{rank}
             </Badge>
 
             {/* Facet Badge */}
@@ -62,47 +68,52 @@ export function ValueCard({ value, rank, onEdit, onDelete }: ValueCardProps) {
               {facetConfig.label}
             </Badge>
           </div>
+
+          {/* Dropdown menu for actions */}
+          {(onEdit || onDelete) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  aria-label="Actions"
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {onEdit && (
+                  <DropdownMenuItem onClick={onEdit}>
+                    <Edit className="h-4 w-4 mr-2" />
+                    Edit
+                  </DropdownMenuItem>
+                )}
+                {onDelete && (
+                  <DropdownMenuItem
+                    onClick={onDelete}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    Delete
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {/* Content */}
-        <p
-          className={`${isTopValue ? 'text-base font-medium' : 'text-sm'} text-foreground leading-relaxed`}
-        >
+        <p className="text-sm text-foreground leading-relaxed">
           {value.content}
         </p>
-
-        {/* Actions */}
-        <div className="flex gap-2 pt-2">
-          {onEdit && (
-            <Button size="sm" variant="outline" onClick={onEdit} className="flex-1">
-              <Edit className="h-4 w-4 mr-1" />
-              Edit
-            </Button>
-          )}
-          {onDelete && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onDelete}
-              aria-label="Delete value"
-              className="text-destructive hover:bg-destructive hover:text-destructive-foreground"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          )}
-        </div>
-
-        {/* Metadata (small timestamp) */}
         <p className="text-xs text-muted-foreground">
           Updated{' '}
           {(() => {
             try {
               const date = new Date(value.dateUpdated);
-              if (isNaN(date.getTime())) {
-                return 'recently';
-              }
+              if (isNaN(date.getTime())) return 'recently';
               return date.toLocaleDateString();
             } catch {
               return 'recently';

--- a/frontend/components/features/ValueDragItem.tsx
+++ b/frontend/components/features/ValueDragItem.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Value } from '@/lib/types';
+import { ValueCard } from './ValueCard';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ValueDragItemProps {
+  value: Value;
+  rank: number;
+  onEdit: (value: Value) => void;
+  onDelete: (value: Value) => void;
+}
+
+export function ValueDragItem({
+  value,
+  rank,
+  onEdit,
+  onDelete,
+}: ValueDragItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: value.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex gap-2 items-stretch">
+      {/* Always visible drag handle */}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="flex-shrink-0 cursor-grab active:cursor-grabbing h-auto"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-5 w-5 text-muted-foreground" />
+      </Button>
+
+      {/* Card wrapper */}
+      <div className="flex-1">
+        <ValueCard
+          value={value}
+          rank={rank}
+          isDragging={isDragging}
+          onEdit={() => onEdit(value)}
+          onDelete={() => onDelete(value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/features/ValueList.tsx
+++ b/frontend/components/features/ValueList.tsx
@@ -1,16 +1,33 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { api } from '@/lib/api';
 import { Value } from '@/lib/types';
-import { ValueCard } from './ValueCard';
+import { ValueDragItem } from './ValueDragItem';
+import { EmptySlot } from './EmptySlot';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2 } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useValueReordering } from '@/hooks/useValueReordering';
 
 interface ValueListProps {
-  refresh?: number; // Trigger refetch when this changes
-  onValueEdit?: (value: Value) => void;
-  onValueDelete?: (value: Value) => void;
+  refresh?: number;
+  onValueEdit: (value: Value) => void;
+  onValueDelete: (value: Value) => void;
   onValuesCountChange?: (count: number) => void;
 }
 
@@ -23,6 +40,14 @@ export function ValueList({
   const [values, setValues] = useState<Value[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { handleValueReorder, isUpdating } = useValueReordering();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   useEffect(() => {
     const fetchValues = async () => {
@@ -31,16 +56,15 @@ export function ValueList({
 
       try {
         const response = await api.values.getAll();
-        // Sort by displayOrder (already sorted by backend, but double-check)
-        const sortedValues = [...response.items].sort((a, b) => a.displayOrder - b.displayOrder);
+        const sortedValues = [...response.items].sort(
+          (a, b) => a.displayOrder - b.displayOrder,
+        );
         setValues(sortedValues);
-
-        // Notify parent of values count
-        if (onValuesCountChange) {
-          onValuesCountChange(sortedValues.length);
-        }
-      } catch (err: any) {
-        setError(err.message || 'Failed to load values');
+        onValuesCountChange?.(sortedValues.length);
+      } catch (err: unknown) {
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to load values';
+        setError(errorMessage);
       } finally {
         setIsLoading(false);
       }
@@ -48,6 +72,42 @@ export function ValueList({
 
     fetchValues();
   }, [refresh, onValuesCountChange]);
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = values.findIndex((v) => v.id === active.id);
+      const newIndex = values.findIndex((v) => v.id === over.id);
+
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      // Keep original for rollback
+      const originalValues = [...values];
+
+      // Optimistic update
+      const newValues = arrayMove(values, oldIndex, newIndex);
+      const updatedValues = newValues.map((value, index) => ({
+        ...value,
+        displayOrder: index + 1,
+      }));
+      setValues(updatedValues);
+
+      // Save to backend (pass both original and new arrays)
+      const rollbackValues = await handleValueReorder(
+        originalValues,
+        updatedValues,
+      );
+
+      // Rollback if error
+      if (rollbackValues) {
+        setValues(rollbackValues);
+      }
+    },
+    [values, handleValueReorder],
+  );
 
   if (isLoading) {
     return (
@@ -65,27 +125,55 @@ export function ValueList({
     );
   }
 
-  if (values.length === 0) {
-    return (
-      <Alert className="bg-rose-50 border-rose-200">
-        <AlertDescription className="text-rose-900">
-          You haven&apos;t created any values yet. Start by defining what matters most to you.
-        </AlertDescription>
-      </Alert>
-    );
-  }
+  // Generate 10 slots
+  const slots = Array.from({ length: 10 }, (_, i) => {
+    const slotNumber = i + 1;
+    const value = values.find((v) => v.displayOrder === slotNumber);
+    return { slotNumber, value };
+  });
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {values.map((value, index) => (
-        <ValueCard
-          key={value.id}
-          value={value}
-          rank={index + 1}
-          onEdit={() => onValueEdit?.(value)}
-          onDelete={() => onValueDelete?.(value)}
-        />
-      ))}
+    <div className="relative">
+      {/* Loading overlay during save */}
+      {isUpdating && (
+        <div className="absolute inset-0 bg-white/50 flex items-center justify-center z-50 rounded-lg">
+          <div className="flex flex-col items-center gap-2">
+            <Loader2 className="h-6 w-6 animate-spin text-rose-600" />
+            <p className="text-sm text-muted-foreground">Saving order...</p>
+          </div>
+        </div>
+      )}
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={values.map((v) => v.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-3">
+            {slots.map(({ slotNumber, value }) => {
+              if (!value) {
+                return (
+                  <EmptySlot key={`empty-${slotNumber}`} slotNumber={slotNumber} />
+                );
+              }
+
+              return (
+                <ValueDragItem
+                  key={value.id}
+                  value={value}
+                  rank={slotNumber}
+                  onEdit={onValueEdit}
+                  onDelete={onValueDelete}
+                />
+              );
+            })}
+          </div>
+        </SortableContext>
+      </DndContext>
     </div>
   );
 }

--- a/frontend/hooks/useValueReordering.ts
+++ b/frontend/hooks/useValueReordering.ts
@@ -1,0 +1,111 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Value } from '@/lib/types';
+import { api } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+
+export function useValueReordering() {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { toast } = useToast();
+  const previousStateRef = useRef<Value[] | null>(null);
+  const isUpdatingRef = useRef(false);
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    isUpdatingRef.current = isUpdating;
+  }, [isUpdating]);
+
+  const handleValueReorder = useCallback(
+    async (
+      originalValues: Value[],
+      newValues: Value[],
+    ): Promise<Value[] | null> => {
+      if (isUpdatingRef.current) return null;
+
+      // Save previous state for rollback
+      previousStateRef.current = [...originalValues];
+      setIsUpdating(true);
+
+      try {
+        // Find values that changed displayOrder
+        const updates = newValues
+          .map((newVal, index) => {
+            const newOrder = index + 1;
+            const originalVal = originalValues.find((v) => v.id === newVal.id);
+            if (originalVal && originalVal.displayOrder !== newOrder) {
+              return { id: newVal.id, newOrder };
+            }
+            return null;
+          })
+          .filter((u): u is { id: string; newOrder: number } => u !== null);
+
+        if (updates.length === 0) {
+          setIsUpdating(false);
+          return null;
+        }
+
+        // Find an empty slot to use as temporary parking
+        const usedOrders = new Set(originalValues.map((v) => v.displayOrder));
+        let emptySlot: number | null = null;
+        for (let i = 1; i <= 10; i++) {
+          if (!usedOrders.has(i)) {
+            emptySlot = i;
+            break;
+          }
+        }
+
+        if (emptySlot !== null) {
+          // We have an empty slot - use it as parking
+          // 1. Move first affected value to empty slot
+          // 2. Update others sequentially
+          // 3. Move parked value to final position
+          const [firstUpdate, ...restUpdates] = updates;
+
+          // Park first value in empty slot
+          await api.values.update(firstUpdate.id, { displayOrder: emptySlot });
+
+          // Update others sequentially
+          for (const update of restUpdates) {
+            await api.values.update(update.id, { displayOrder: update.newOrder });
+          }
+
+          // Move parked value to final position
+          await api.values.update(firstUpdate.id, {
+            displayOrder: firstUpdate.newOrder,
+          });
+        } else {
+          // All 10 slots full - cannot reorder without backend support
+          throw new Error(
+            'Cannot reorder when all 10 slots are full. Delete a value first.',
+          );
+        }
+
+        toast({
+          title: 'Values reordered',
+          description: 'Your value priorities have been updated.',
+        });
+
+        return null; // Success, no rollback needed
+      } catch (error) {
+        toast({
+          variant: 'destructive',
+          title: 'Error saving order',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Failed to save value order. Your changes have been reverted.',
+        });
+
+        // Return previous state for rollback
+        return previousStateRef.current;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [toast],
+  );
+
+  return {
+    handleValueReorder,
+    isUpdating,
+  };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -293,6 +296,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,9 @@
     "check": "npm run typecheck && npm run lint && npm run format:check"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary

- Remove stats cards from dashboard (Thinks, Values, Goals, Habits counts)
- Change values page from grid to vertical list layout with drag-and-drop reordering
- Add @dnd-kit for drag-and-drop functionality with optimistic updates and rollback on error
- Always show 10 value slots (filled values + empty placeholders)
- Replace inline edit/delete buttons with a 3-dot dropdown menu
- Remove #1 special styling - all values now have uniform badge styling
- Update info alert to mention drag-and-drop and that gaps are allowed on delete

## Test plan

- [ ] Verify dashboard loads without stats cards
- [ ] Navigate to /values and verify vertical list layout
- [ ] Create a few values and verify they appear in slots
- [ ] Drag a value to reorder and verify order persists after refresh
- [ ] Verify empty slots display correctly with placeholder text
- [ ] Test dropdown menu (Edit/Delete actions)
- [ ] Verify loading overlay appears during save
- [ ] Test error rollback by simulating API failure (optional)
- [ ] Test on mobile (touch drag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop reordering for values with a saving overlay and visual drag state.
  * Empty slot visuals to show available positions.

* **Improvements**
  * Actions moved into a compact dropdown menu on value cards.
  * Priority badges unified; list shows explicit display order.
  * Instruction text updated to guide drag-to-reorder and gaps.

* **Changes**
  * Removed Quick Stats from the dashboard.
  * "View all" label changed to "Manage".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->