### PR TITLE
fix: enforce string values in AI parsed_data response

### DIFF
--- a/app/jobs/telegrammessage/prompts/system.md
+++ b/app/jobs/telegrammessage/prompts/system.md
@@ -19,6 +19,12 @@ Always respond with valid JSON:
   "status": "approved" | "needs_refinement",
   "feedback": "User-facing message in Spanish",
   "parsed_data": {
-    "field_name": "extracted value"
+    "field_name": "extracted value as STRING"
   }
 }
+
+CRITICAL: All parsed_data values MUST be strings, never arrays or objects.
+- CORRECT: "emociones": "tristeza, ansiedad"
+- WRONG: "emociones": ["tristeza", "ansiedad"]
+- If multiple values, join with comma: "value1, value2"
+- If null/empty, use empty string: ""


### PR DESCRIPTION
## Summary

Fixes AI response parsing error where Claude returns arrays instead of strings in `parsed_data`.

**Error observed:**
```
json: cannot unmarshal array into Go struct field AIStepResult.parsed_data of type string
```

**AI was returning:**
```json
"parsed_data": {
  "emociones": ["tristeza", "decepción", "ansiedad"]  // Array - WRONG
}
```

**Expected:**
```json
"parsed_data": {
  "emociones": "tristeza, decepción, ansiedad"  // String - CORRECT
}
```

## Changes

Updated `prompts/system.md` to explicitly instruct Claude:
- All `parsed_data` values MUST be strings
- Multiple values should be comma-separated
- Null/empty values should be empty string `""`

## Test plan

- [ ] Deploy to production
- [ ] Send `/momento` and complete step 2 with emotions
- [ ] Verify no `parse_failed` errors in logs
- [ ] Verify session advances to step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed data extraction formatting to ensure all parsed values are returned as strings rather than arrays or objects, improving consistency in data handling.

* **Documentation**
  * Updated guidance on handling multi-value fields with comma-separated formatting and clarified null/empty value handling requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->